### PR TITLE
Change platform weight for documentation restructure

### DIFF
--- a/Documentation/_index.md
+++ b/Documentation/_index.md
@@ -2,7 +2,7 @@
 title: General
 description: Topics that will give you an overview of the Dolittles PaaS offering 
 keywords: Platform, PaaS, General
-weight: 1
+weight: 10
 repository: https://github.com/dolittle-platform/home
 ---
 This holds the overview of what the Dolittle PaaS offering is all about


### PR DESCRIPTION
Should be added together with the [documentation restructurization](https://github.com/dolittle/Documentation/pull/68)